### PR TITLE
fuzzy match match/odds names example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/JoinMatchOdds.R
+++ b/JoinMatchOdds.R
@@ -1,0 +1,34 @@
+
+# setup -------------------------------------------------------------------
+
+library(dplyr)
+library(readr)
+library(stringr)
+library(fuzzyjoin)
+
+matches <- read_csv(
+  "https://raw.githubusercontent.com/wesfb/disso/main/match_data_new%202.csv"
+)
+
+odds <- read_csv(
+  "https://raw.githubusercontent.com/wesfb/disso/main/matches_and_odds.csv"
+)
+
+odds$Date <- as.Date(odds$Date)
+
+# names -------------------------------------------------------------------
+
+matches_names <- tibble(match_name = unique(c(matches$player_i, matches$player_j)))
+odds_names <- tibble(odds_name = unique(c(odds$Winner, odds$Loser)))
+
+# fuzzy match
+matched_names <- stringdist_left_join(
+  matches_names, odds_names, by = c("match_name"="odds_name"),
+  method = "jw", distance_col = "dist"
+  )
+
+best_matches <- matched_names %>% 
+  group_by(match_name) %>% 
+  arrange(match_name,dist)
+
+# join --------------------------------------------------------------------

--- a/JoinMatchOdds.R
+++ b/JoinMatchOdds.R
@@ -19,16 +19,40 @@ odds$Date <- as.Date(odds$Date)
 # names -------------------------------------------------------------------
 
 matches_names <- tibble(match_name = unique(c(matches$player_i, matches$player_j)))
+matches_names$match_name_rev <- sapply(
+  strsplit(matches_names$match_name, "\\s+"), function(x) paste(rev(x), collapse=" ")
+  )
+
 odds_names <- tibble(odds_name = unique(c(odds$Winner, odds$Loser)))
 
 # fuzzy match
 matched_names <- stringdist_left_join(
-  matches_names, odds_names, by = c("match_name"="odds_name"),
+  matches_names, odds_names, by = c("match_name_rev"="odds_name"),
   method = "jw", distance_col = "dist"
   )
 
 best_matches <- matched_names %>% 
   group_by(match_name) %>% 
-  arrange(match_name,dist)
+  dplyr::filter(dist == min(dist))
 
 # join --------------------------------------------------------------------
+
+matches_odds <- matches %>% 
+  # join name lookup
+  left_join(
+    select(best_matches, match_name, odds_name),
+    by = c("winner_name"="match_name")
+    ) %>% 
+  left_join(
+    select(best_matches, match_name, odds_name),
+    by = c("loser_name"="match_name")
+  ) %>% 
+  # join odds data
+  left_join(
+    odds, by = c(
+      "tourney_date"="Date",
+      "odds_name.x"="Winner",
+      "odds_name.y"="Loser"
+    )
+  )
+

--- a/disso_new.Rproj
+++ b/disso_new.Rproj
@@ -1,0 +1,13 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX


### PR DESCRIPTION
added `JoinMatchOdds.R` which creates string distance table (i.e. fuzzy match) between (full) names in matches and (abbreviated) names in odds data. 

Unsure whether this will lead to sufficiently accurate result. Many cases where string distance metrics return low distance metric (i.e. high similarity) but appear wrong on inspection. For example, `Agustin Velotti` is matched most closely to `Agostinelli B.`. You might need to see if alternative odds data with full player names is available anywhere.